### PR TITLE
Add a warning of too strict version constraints to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ Available options:
   -c,--cabal CABALFILE     cabal file to update (.cabal)
 ```
 
+A word of warning
+-----------------
+
+Too strict version bounds can severely limit your compatibility with the rest
+of the Haskell ecosystem. 
+If your package is published to be used by other people in different setups,
+especially as a library, you should ideally have version bounds compatible
+with stackage LTS, stackage nightly and the current newest versions on hackage.
+If your package does not actually work in all those setups, that’s fine, but
+try to avoid unnecessarily restricting those usecases.
+
 Features and limitations
 ------------------------
 


### PR DESCRIPTION
Everytime I look at this package I break into cold sweat. I agree that it is a very useful tool and that having very loose lower bounds can sometimes be considered a lie. On the other hand too strict version constraints can limit the possibility for users to find valid build plans and are a bane for stackage and nixpkgs maintainers.
[We already discussed this on discourse](https://discourse.haskell.org/t/dependency-version-bounds-are-a-lie/5522/34).

Because of those concerns I suggest adding a note about this into the readme. I think there is a correct way to use this package, and I am actually considering using it for my own libraries. But I think that setup requires medium complex ci and I am afraid of people simply rerunning cabal-plan-bounds with the freshest possible versions from hackage, whenever they want to raise any of their bounds.

The suggested text is just a suggestion and I am neither married to the wording not the content. I am very open to workshop it, but I would be really happy if you agreed to put some wording to this effect into the README.