### PR TITLE
Group changes by Cabal file

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
     haskell.compiler.ghc944
     haskell.compiler.ghc962
     haskell.compiler.ghc981
+    cabal-install
     ghcid
   ];
 }

--- a/src/cabal-plan-bounds.hs
+++ b/src/cabal-plan-bounds.hs
@@ -132,11 +132,16 @@ work dry_run extend explicits planfiles cabalfiles = do
 
       let (contents', fieldChanges) = replaceDependencies new_deps contents
 
-      forM_ (cleanChanges fieldChanges) $ \(pn, (olds, new)) ->
-        putStrLn $ render $
-            hang (pretty pn) 4 $ vcat $
-                [ char '-' <+> pretty old | old <- olds ] <>
-                [ char '+' <+> pretty new ]
+      let packageChanges =
+            map (\(pn, (olds, new)) ->
+                  hang (pretty pn) 4 $ vcat $
+                      [ char '-' <+> pretty old | old <- olds ] <>
+                      [ char '+' <+> pretty new ])
+                (cleanChanges fieldChanges)
+      unless (null packageChanges) $
+          putStrLn $ render $
+              (if length cabalfiles > 1 then hang (pretty pname) 4 else id) $
+                  vcat packageChanges
 
       unless dry_run $
           unless (contents == contents') $


### PR DESCRIPTION
If there are multiple Cabal files provided, include the package name from the Cabal file in the output, above the set of changes related to that Cabal file.

## examples

A single Cabal file has the same output as before this change:
``` bash
$ cabal-plan-bounds --dry-run */cache/plan.json --cabal core/my-package.cabal
base
    - ^>=4.14.3 || ^>=4.15.1 || ^>=4.16.3 || ^>=4.17.0 || ^>=4.18.0 || ^>=4.19.0 || ^>=4.20.0
    + ^>=4.14.3 || ^>=4.15.1
bytestring
    - ^>=0.10.12 || ^>=0.11.3 || ^>=0.12.0
    + ^>=0.10.12
containers
    - ^>=0.6.4 || ^>=0.7
    + ^>=0.6.4
```

**new** Multiple Cabal files induces grouping by package:
``` bash
$ cabal-plan-bounds */cache/plan.json --cabal core/my-package.cabal --cabal other/my-other-package.cabal
my-package
    base
        - ^>=4.14.3 || ^>=4.15.1 || ^>=4.16.3 || ^>=4.17.0 || ^>=4.18.0 || ^>=4.19.0 || ^>=4.20.0
        + ^>=4.14.3 || ^>=4.15.1
    bytestring
        - ^>=0.10.12 || ^>=0.11.3 || ^>=0.12.0
        + ^>=0.10.12
    containers
        - ^>=0.6.4 || ^>=0.7
        + ^>=0.6.4
my-other-package
    base
        - ^>=4.14.3 || ^>=4.15.1 || ^>=4.16.3 || ^>=4.17.0 || ^>=4.18.0 || ^>=4.19.0 || ^>=4.20.0
        + ^>=4.14.3 || ^>=4.15.1
    optparse-applicative
        - ^>=0.17.0 || ^>=0.18.1
        + ^>=0.17.0
    text
        - ^>=1.2.4 || ^>=2.0.1 || ^>=2.1
        + ^>=1.2.4
```

And if there are no changes, even with multiple packages, there is no output (just like before), meaning it’s still easy to simulate `--check`:
``` bash
#!/usr/bin/env bash

diffs=$(cabal-plan-bounds --dry-run */cache/plan.json --cabal core/my-package.cabal --cabal other/my-other-package.cabal)

if [[ -n "$diffs" ]]; then
  echo "$diffs"
  exit 1
fi
```

## context

I often have multiple Cabal packages in one repo, and run `cabal-plan-bounds` across them all at once. I just ran into a case where _one_ package out of five ended up with more restrictive bounds on a particular dependency. My guess is that it was restricted in a transitive dependency, so couldn’t solve with the same version for a particular plan.

Anyway, I use `--dry-run` because I use `^>= {…}` syntax in my Cabal files, and the output from `cabal-plan-bounds` didn’t tell me anything about which package I should tighten the bounds on. It’s just that it listed only that one dependency once that I knew it only affected one of my packages. This change clarifies the situation, without affecting output in the single-Cabal-file case.

## other options

It might be good to _always_ include the package name in the output, even with just one Cabal file. That makes the formatting more consistent if someone wants to process it programatically (but I think it would be better to have JSON or some other output format for that case).