### PR TITLE
Add `--check` to fail if changes would be made

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,17 +120,17 @@ Usage
 $ cabal-plan-bounds --help
 Derives dependency bounds from build plans
 
-Usage: cabal-plan-bounds [-n|--dry-run] [--extend] [--also ARG] [PLAN]
-                         [-c|--cabal CABALFILE]
+Usage: cabal-plan-bounds [-n|--dry-run] [-k|--check] [--extend] [--also ARG]
+                         [PLAN] [-c|--cabal CABALFILE]
 
 Available options:
   -h,--help                Show this help text
   -n,--dry-run             do not actually write .cabal files
+  -k,--check               fail if there are changes (implies ‘--dry-run’)
   --extend                 only extend version ranges
   --also ARG               additional versions (pkg-1.2.3 or "pkg ==1.2.3")
   PLAN                     plan file to read (.json)
   -c,--cabal CABALFILE     cabal file to update (.cabal)
-
 ```
 
 Features and limitations
@@ -167,6 +167,4 @@ Future work (contributions welcome!)
 
 * Proper error handling, e.g. while parsing.
 * A test suite
-* A `--check` mode that does not touch the `.cabal` file, but fails if it would
-  change it (for CI).
 * Update the `tested-with` field according to the compiler versions used.

--- a/shell.nix
+++ b/shell.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
     haskell.compiler.ghc944
     haskell.compiler.ghc962
     haskell.compiler.ghc981
+    cabal-install
     ghcid
   ];
 }

--- a/src/cabal-plan-bounds.hs
+++ b/src/cabal-plan-bounds.hs
@@ -132,11 +132,16 @@ work dry_run extend explicits planfiles cabalfiles = do
 
       let (contents', fieldChanges) = replaceDependencies new_deps contents
 
-      forM_ (cleanChanges fieldChanges) $ \(pn, (olds, new)) ->
-        putStrLn $ render $
-            hang (pretty pn) 4 $ vcat $
-                [ char '-' <+> pretty old | old <- olds ] <>
-                [ char '+' <+> pretty new ]
+      let packageChanges =
+            map (\(pn, (olds, new)) ->
+                  hang (pretty pn) 4 $ vcat $
+                      [ char '-' <+> pretty old | old <- olds ] <>
+                      [ char '+' <+> pretty new ])
+                (cleanChanges fieldChanges)
+      unless (null packageChanges) $
+          putStrLn $ render $
+              (if length cabalfiles > 1 then hang (pretty pname) 4 else id) $
+                  vcat packageChanges
 
       unless dry_run $
           unless (contents == contents') $

--- a/src/cabal-plan-bounds.hs
+++ b/src/cabal-plan-bounds.hs
@@ -12,6 +12,7 @@ import Control.Monad
 import Data.Bifunctor
 import Data.List
 import Cabal.Plan
+import System.Exit (exitFailure)
 import Text.PrettyPrint hiding ((<>))
 
 import qualified Distribution.PackageDescription.Parsec as C
@@ -36,6 +37,7 @@ main = join . customExecParser (prefs showHelpOnError) $
     parser :: Parser (IO ())
     parser = work
       <$> switch (long "dry-run" <> short 'n' <> help "do not actually write .cabal files")
+      <*> switch (long "check" <> short 'k' <> help "fail if there are changes (implies ‘--dry-run’)")
       <*> switch (long "extend" <> help "only extend version ranges")
       <*> many (option packageVersionP (long "also" <> help "additional versions (pkg-1.2.3 or \"pkg ==1.2.3\")"))
       <*> many (argument
@@ -108,11 +110,11 @@ cleanChanges changes =
     M.fromListWith (\(olds1, new1) (olds2, _new2) -> (olds1 <> olds2, new1)) $
     [ (pname, ([old], new)) | (pname, old, new) <- changes, old /= new ]
 
-work :: Bool -> Bool -> [(C.PackageName, C.Version)] -> [FilePath] -> [FilePath] -> IO ()
-work dry_run extend explicits planfiles cabalfiles = do
+work :: Bool -> Bool -> Bool -> [(C.PackageName, C.Version)] -> [FilePath] -> [FilePath] -> IO ()
+work dry_run check extend explicits planfiles cabalfiles = do
     plans <- mapM decodePlanJson planfiles
 
-    forM_ cabalfiles $ \cabalfile -> do
+    changes <- forM cabalfiles $ \cabalfile -> do
       contents <- BS.readFile cabalfile
 
       -- Figure out package name
@@ -138,12 +140,13 @@ work dry_run extend explicits planfiles cabalfiles = do
                       [ char '-' <+> pretty old | old <- olds ] <>
                       [ char '+' <+> pretty new ])
                 (cleanChanges fieldChanges)
-      unless (null packageChanges) $
+      unless (null packageChanges) $ do
           putStrLn $ render $
               (if length cabalfiles > 1 then hang (pretty pname) 4 else id) $
                   vcat packageChanges
-
-      unless dry_run $
-          unless (contents == contents') $
+          unless (dry_run || check) $
               -- TODO: Use atomic-write
               BS.writeFile cabalfile contents'
+      pure packageChanges
+
+    when (check && not (all null changes)) exitFailure


### PR DESCRIPTION
This also ensures that the file won’t be touched (even without `--check`) if there are no changes to the dependency ranges[^1].

[^1]: This might already have been the case, but I’m not sure if `replaceDependencies` might introduce formatting changes around dependencies, even if there’s no change to the range.

**NB**: This is currently based on #25 (only the third commit is specific to this change), because it uses `packageChanges`, but could be made independent if #25 won’t get in.